### PR TITLE
Modify aria labels in pagination template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.10] - 2021-10-18
+
+- Added: pagination translation on aria-label
+- Changed: aria-label on pagination buttons
+
 ## [0.1.9] - 2021-10-13
 
 - Added: added `explanation` eval option to `form_textfield_bs5.html.twig`

--- a/src/Resources/translations/messages.de.yml
+++ b/src/Resources/translations/messages.de.yml
@@ -1,1 +1,6 @@
-huh.twig.templates.framework.bs5: "Bootstrap 5"
+huh:
+  twig:
+    templates:
+      framework:
+        bs5: "Bootstrap 5"
+

--- a/src/Resources/translations/messages.en.yml
+++ b/src/Resources/translations/messages.en.yml
@@ -1,1 +1,5 @@
-huh.twig.templates.framework.bs5: "Bootstrap 5"
+huh:
+  twig:
+    templates:
+      framework:
+        bs5: "Bootstrap 5"

--- a/src/Resources/views/pagination/pagination_bs5.html.twig
+++ b/src/Resources/views/pagination/pagination_bs5.html.twig
@@ -1,5 +1,5 @@
 <!-- indexer::stop -->
-<nav class="pagination-wrapper block" aria-label="Page navigation">
+<nav class="pagination-wrapper block" aria-label="{{ 'MSC.pagination'|trans({}, 'contao_default') }}">
     <p>{{ total }}</p>
 
     <ul class="pagination">
@@ -8,7 +8,7 @@
         {% endif %}
 
         {% if hasPrevious|default %}
-            <li class="page-item previous"><a role="button" href="{{ previous.href|raw }}" class="page-link previous" aria-label="{{ previous.title }}" title="{{ previous.title }}">{{ previous.link|raw }}</a>
+            <li class="page-item previous"><a role="button" href="{{ previous.href|raw }}" class="page-link previous" aria-label="{{ previous.link|raw }}, {{ previous.title }}" title="{{ previous.title }}">{{ previous.link|raw }}</a>
             </li>
         {% endif %}
 
@@ -21,11 +21,11 @@
         {% endfor %}
 
         {% if hasNext|default %}
-            <li class="page-item next"><a role="button" href="{{ next.href|raw }}" class="page-link next" aria-label="{{ next.title }}" title="{{ next.title }}">{{ next.link|raw }}</a></li>
+            <li class="page-item next"><a role="button" href="{{ next.href|raw }}" class="page-link next" aria-label="{{ next.link|raw }}, {{ next.title }}" title="{{ next.title }}">{{ next.link|raw }}</a></li>
         {% endif %}
 
         {% if hasLast|default %}
-            <li class="page-item last"><a role="button" href="{{ last.href|raw }}" class="page-link last" aria-label="{{ last.title }}" title="{{ last.title }}">{{ last.link|raw }}</a></li>
+            <li class="page-item last"><a role="button" href="{{ last.href|raw }}" class="page-link last" aria-label="{{ last.link|raw }}, {{ last.title }}" title="{{ last.title }}">{{ last.link|raw }}</a></li>
         {% endif %}
     </ul>
 </nav>


### PR DESCRIPTION
Accessibility requires the label need to be the same as the text is showing of a button. This PR will fix just that for the pagination template