### PR TITLE
Create ce_youtube_bs5.html.twig

### DIFF
--- a/src/Resources/views/elements/ce_youtube_bs5.html.twig
+++ b/src/Resources/views/elements/ce_youtube_bs5.html.twig
@@ -1,0 +1,7 @@
+{% extends '@HeimrichHannotTwigTemplates/block/block_unsearchable.html.twig' %}
+
+{% block content %}
+    <div class="ratio ratio-16x9">
+        <iframe src="{{ src|default }}" allowfullscreen></iframe>
+    </div>
+{% endblock %}


### PR DESCRIPTION
Responsive embed helpers have been renamed to ratio helpers in bs5 
see https://getbootstrap.com/docs/5.2/migration/#helpers