### PR TITLE
Update form_wrapper_bs5.html.twig

### DIFF
--- a/src/Resources/views/forms/form_wrapper_bs5.html.twig
+++ b/src/Resources/views/forms/form_wrapper_bs5.html.twig
@@ -7,7 +7,7 @@
         {% if method != 'get' %}
             <input type="hidden" name="FORM_SUBMIT" value="{{ formSubmit|default }}">
             <input type="hidden" name="REQUEST_TOKEN" value="{{ '{{request_token}}' }}">
-            {% if maxFileSize %}
+            {% if maxFileSize|default %}
                 <input type="hidden" name="MAX_FILE_SIZE" value="{{ maxFileSize|default }}">
             {% endif %}
         {% endif %}


### PR DESCRIPTION
Add default filter because of errors with other contao extensions & forms like the calendar-event-booking-bundle